### PR TITLE
Updates the routing to get custom 404 page to work

### DIFF
--- a/now.json
+++ b/now.json
@@ -7,6 +7,8 @@
     { "src": "workspaces/homepage/package.json", "use": "@now/static-build", "config": {"distDir": "public"} }
   ],
   "routes": [
-    { "src": "/(?<path>.*)", "dest": "/workspaces/homepage/$path"}
+    { "src": "/(?<path>.*)", "dest": "/workspaces/homepage/$path", "continue": true },
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/workspaces/homepage/404" }
   ]
 }


### PR DESCRIPTION
This PR updates the routing table to take get the custom Gatsby 404 page to work with Zeit deployment.

The change was to take advantage of the `filesystem` route (https://zeit.co/docs/configuration/#routes/advanced/spa-fallback) but then do rewriting with the special `continue` route param set to `true` to get the whole thing working with a monorepo:

```json
"routes": [
    { "src": "/(?<path>.*)", "dest": "/workspaces/homepage/$path", "continue": true },
    { "handle": "filesystem" },
    { "src": "/.*", "dest": "/workspaces/homepage/404" }
  ]
```

So the first route makes sure we are redirecting to the correct `filesystem` root. The route matches everything but then matching does not stop and goes to the next rule (`continue: true`). Then if there is a machine path (recall Gatsby is static) it will be served as intended, otherwise we will be redirected to custom 404.