### PR TITLE
gatsby-theme-confluenza: ignore .files

### DIFF
--- a/workspaces/gatsby-theme-confluenza/gatsby-config.js
+++ b/workspaces/gatsby-theme-confluenza/gatsby-config.js
@@ -30,7 +30,8 @@ module.exports = ({ mdx = false }) => ({
           '**/public/**',
           '**/es/**',
           '**/lib/**',
-          '**/umd/**'
+          '**/umd/**',
+          '/**/.*'
         ]
       }
     },


### PR DESCRIPTION
.files (dot-file) mostly does not contain any content and often these are file we would better hide from Confluenza. This pull request adds an extra ignore line to `gatsby-source-filesystem` configuration in `gatsby-theme-confluenza`:

```javascript
plugins: [
    {
      resolve: 'gatsby-source-filesystem',
      options: {
        path: `${rootPath()}`,
        ignore: [
          '**/.git/**',
          '**/coverage/**',
          '**/node_modules/**',
          '**/.cache/**',
          '**/public/**',
          '**/es/**',
          '**/lib/**',
          '**/umd/**',
          '/**/.*' // <==== added this one
        ]
      }
    },
```