### PR TITLE
Improves rendering of the navigation menu for tiny screens

### DIFF
--- a/workspaces/component-navigator-react/source/documentation-layout/DocumentationLayoutSmall.js
+++ b/workspaces/component-navigator-react/source/documentation-layout/DocumentationLayoutSmall.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 
 import { DocumentationLayoutGrid, SidebarGridItem, ContentGridItem } from './DocumentationLayoutGrid'
 import { Navigation } from '../navigation'
@@ -17,6 +17,8 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
   const [transition, setTransition] = useState('none')
   const [animationSpan, setAnimationSpan] = useState(0)
   const animationDuration = 0.3
+  const openingTimeout = useRef(undefined)
+  const closingTimeout = useRef(undefined)
 
   const {
     recordScrollPosition,
@@ -48,8 +50,10 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
   const toggleMenu = () => {
     enableMenuAnimation(animationDuration, 0)
     if (menuActive) {
+      clearTimeout(openingTimeout.current)
       closeMenu()
     } else {
+      clearTimeout(closingTimeout.current)
       setMenuActive(true)
       // record scroll position so that we can restore it if needed
       recordScrollPosition()
@@ -72,8 +76,9 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
       // We do not want to change to 'position: fixed' immediately as
       // this may be visible and create unpleasant visual effect.
       // The timeout is about the same as the transition duration in CSS.
-      setTimeout(() => {
+      openingTimeout.current = setTimeout(() => {
         setPosition('fixed')
+        disableMenuAnimation()
       }, animationSpan)
     } else {
       // Restoring scroll position can only be effective
@@ -87,7 +92,7 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
       // 'position: fixed' to 'position: relative' needs to be effective
       // before we can change the scroll position.
       restoreScrollPosition()
-      setTimeout(() => {
+      closingTimeout.current = setTimeout(() => {
         disableMenuAnimation()
       }, animationSpan)
     }
@@ -111,9 +116,11 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
         <SidebarGridItem>
           <FixedNavigation
             rhythm={rhythm} css={{
+              left: menuActive ? '0' : '-100vw',
               minWidth: '100vw',
               maxWidth: '100vw',
-              height: '100vh'
+              height: '100vh',
+              transition
             }}
           >
             <SiteTitle title={title} />

--- a/workspaces/component-navigator-react/source/documentation-layout/DocumentationLayoutSmall.js
+++ b/workspaces/component-navigator-react/source/documentation-layout/DocumentationLayoutSmall.js
@@ -11,11 +11,12 @@ import { FixedNavigation } from './FixedNavigation'
 import { useScrollResoration } from './useScrollRestoration'
 import { useMobileDocumentNavigator } from './useMobileDocumentNavigator'
 
-const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, deltas }) => {
+const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, deltas, rhythm }) => {
   const [menuActive, setMenuActive] = useState(false)
   const [position, setPosition] = useState('relative')
-  const [grid, setGrid] = useState('300px 100vw')
-  const [animationDelay, setAnimationDelay] = useState(0)
+  const [transition, setTransition] = useState('none')
+  const [animationSpan, setAnimationSpan] = useState(0)
+  const animationDuration = 0.3
 
   const {
     recordScrollPosition,
@@ -23,12 +24,20 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
     disableScrollRestoration
   } = useScrollResoration()
 
+  const enableMenuAnimation = (duration, delay) => {
+    setTransition(`all ${duration}s ease-in-out ${delay}s`)
+    setAnimationSpan((duration + delay) * 1000)
+  }
+
+  const disableMenuAnimation = () => {
+    setTransition('none')
+  }
+
   const closeMenu = () => {
     setMenuActive(false)
     // we will be hiding menu - thus, we need to make sure that
     // document container is again scrollable before we see it
     setPosition('relative')
-    setGrid('300px 100vw')
   }
 
   // toggleMenu is used to trigger opening menu, and one of
@@ -37,6 +46,7 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
   // menu is finalized in the effect below that responds to
   // the menuActive change.
   const toggleMenu = () => {
+    enableMenuAnimation(animationDuration, 0)
     if (menuActive) {
       closeMenu()
     } else {
@@ -44,7 +54,6 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
       // record scroll position so that we can restore it if needed
       recordScrollPosition()
     }
-    setAnimationDelay(0)
   }
 
   // This hook responds to the change of location: the user
@@ -53,7 +62,7 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
     onNewPathSelected: () => {
       closeMenu()
       disableScrollRestoration()
-      setAnimationDelay(0.3)
+      enableMenuAnimation(animationDuration, 0.3)
     },
     location
   }, [location])
@@ -65,8 +74,7 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
       // The timeout is about the same as the transition duration in CSS.
       setTimeout(() => {
         setPosition('fixed')
-        setGrid('100vw 100vw')
-      }, 200)
+      }, animationSpan)
     } else {
       // Restoring scroll position can only be effective
       // after position is set back to 'relative'
@@ -79,6 +87,9 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
       // 'position: fixed' to 'position: relative' needs to be effective
       // before we can change the scroll position.
       restoreScrollPosition()
+      setTimeout(() => {
+        disableMenuAnimation()
+      }, animationSpan)
     }
     // eslint-disable-next-line
   }, [menuActive])
@@ -87,22 +98,21 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
   return (
     <>
       <DocumentationLayoutGrid
-        css={{
+        rhythm={rhythm} css={{
           position,
           height: '100vh',
-          left: menuActive ? 0 : '-300px',
+          left: menuActive ? 0 : '-100vw',
           margin: 0,
           gridGap: 0,
-          gridTemplateColumns: grid,
-          transition: `all .2s ease-in-out ${animationDelay}s`
+          gridTemplateColumns: '100vw 100vw',
+          transition
         }}
       >
         <SidebarGridItem>
           <FixedNavigation
-            css={{
-              minWidth: menuActive ? '100vw' : '300px',
-              maxWidth: menuActive ? '100vw' : '300px',
-              transition: `all .2s ease-in-out ${animationDelay}s`,
+            rhythm={rhythm} css={{
+              minWidth: '100vw',
+              maxWidth: '100vw',
               height: '100vh'
             }}
           >

--- a/workspaces/confluenza/source/documentation-layout/DocumentationLayoutSmall.js
+++ b/workspaces/confluenza/source/documentation-layout/DocumentationLayoutSmall.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 
 import { DocumentationLayoutGrid, SidebarGridItem, ContentGridItem } from './DocumentationLayoutGrid'
 import { Navigation } from '../navigation'
@@ -17,6 +17,8 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
   const [transition, setTransition] = useState('none')
   const [animationSpan, setAnimationSpan] = useState(0)
   const animationDuration = 0.3
+  const openingTimeout = useRef(undefined)
+  const closingTimeout = useRef(undefined)
 
   const {
     recordScrollPosition,
@@ -48,8 +50,10 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
   const toggleMenu = () => {
     enableMenuAnimation(animationDuration, 0)
     if (menuActive) {
+      clearTimeout(openingTimeout.current)
       closeMenu()
     } else {
+      clearTimeout(closingTimeout.current)
       setMenuActive(true)
       // record scroll position so that we can restore it if needed
       recordScrollPosition()
@@ -72,8 +76,9 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
       // We do not want to change to 'position: fixed' immediately as
       // this may be visible and create unpleasant visual effect.
       // The timeout is about the same as the transition duration in CSS.
-      setTimeout(() => {
+      openingTimeout.current = setTimeout(() => {
         setPosition('fixed')
+        disableMenuAnimation()
       }, animationSpan)
     } else {
       // Restoring scroll position can only be effective
@@ -87,7 +92,7 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
       // 'position: fixed' to 'position: relative' needs to be effective
       // before we can change the scroll position.
       restoreScrollPosition()
-      setTimeout(() => {
+      closingTimeout.current = setTimeout(() => {
         disableMenuAnimation()
       }, animationSpan)
     }
@@ -111,9 +116,11 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
         <SidebarGridItem>
           <FixedNavigation
             rhythm={rhythm} css={{
+              left: menuActive ? '0' : '-100vw',
               minWidth: '100vw',
               maxWidth: '100vw',
-              height: '100vh'
+              height: '100vh',
+              transition
             }}
           >
             <SiteTitle title={title} />

--- a/workspaces/confluenza/source/documentation-layout/DocumentationLayoutSmall.js
+++ b/workspaces/confluenza/source/documentation-layout/DocumentationLayoutSmall.js
@@ -14,8 +14,9 @@ import { useMobileDocumentNavigator } from './useMobileDocumentNavigator'
 const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, deltas, rhythm }) => {
   const [menuActive, setMenuActive] = useState(false)
   const [position, setPosition] = useState('relative')
-  const [grid, setGrid] = useState('300px 100vw')
-  const [animationDelay, setAnimationDelay] = useState(0)
+  const [transition, setTransition] = useState('none')
+  const [animationSpan, setAnimationSpan] = useState(0)
+  const animationDuration = 0.3
 
   const {
     recordScrollPosition,
@@ -23,12 +24,20 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
     disableScrollRestoration
   } = useScrollResoration()
 
+  const enableMenuAnimation = (duration, delay) => {
+    setTransition(`all ${duration}s ease-in-out ${delay}s`)
+    setAnimationSpan((duration + delay) * 1000)
+  }
+
+  const disableMenuAnimation = () => {
+    setTransition('none')
+  }
+
   const closeMenu = () => {
     setMenuActive(false)
     // we will be hiding menu - thus, we need to make sure that
     // document container is again scrollable before we see it
     setPosition('relative')
-    setGrid('300px 100vw')
   }
 
   // toggleMenu is used to trigger opening menu, and one of
@@ -37,6 +46,7 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
   // menu is finalized in the effect below that responds to
   // the menuActive change.
   const toggleMenu = () => {
+    enableMenuAnimation(animationDuration, 0)
     if (menuActive) {
       closeMenu()
     } else {
@@ -44,7 +54,6 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
       // record scroll position so that we can restore it if needed
       recordScrollPosition()
     }
-    setAnimationDelay(0)
   }
 
   // This hook responds to the change of location: the user
@@ -53,7 +62,7 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
     onNewPathSelected: () => {
       closeMenu()
       disableScrollRestoration()
-      setAnimationDelay(0.3)
+      enableMenuAnimation(animationDuration, 0.3)
     },
     location
   }, [location])
@@ -65,8 +74,7 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
       // The timeout is about the same as the transition duration in CSS.
       setTimeout(() => {
         setPosition('fixed')
-        setGrid('100vw 100vw')
-      }, 200)
+      }, animationSpan)
     } else {
       // Restoring scroll position can only be effective
       // after position is set back to 'relative'
@@ -79,6 +87,9 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
       // 'position: fixed' to 'position: relative' needs to be effective
       // before we can change the scroll position.
       restoreScrollPosition()
+      setTimeout(() => {
+        disableMenuAnimation()
+      }, animationSpan)
     }
     // eslint-disable-next-line
   }, [menuActive])
@@ -90,19 +101,18 @@ const DocumentationLayoutSmall = ({ children, location, data, onStateChanged, de
         rhythm={rhythm} css={{
           position,
           height: '100vh',
-          left: menuActive ? 0 : '-300px',
+          left: menuActive ? 0 : '-100vw',
           margin: 0,
           gridGap: 0,
-          gridTemplateColumns: grid,
-          transition: `all .2s ease-in-out ${animationDelay}s`
+          gridTemplateColumns: '100vw 100vw',
+          transition
         }}
       >
         <SidebarGridItem>
           <FixedNavigation
             rhythm={rhythm} css={{
-              minWidth: menuActive ? '100vw' : '300px',
-              maxWidth: menuActive ? '100vw' : '300px',
-              transition: `all .2s ease-in-out ${animationDelay}s`,
+              minWidth: '100vw',
+              maxWidth: '100vw',
               height: '100vh'
             }}
           >


### PR DESCRIPTION
As described in #17, changes in `gatsby-remark-autolink-headers` caused rendering problems. In #17 I have indicated the problem can be solved by explicitly setting `z-index` on the `ContentGridItem` in [workspaces/confluenza/source/documentation-layout/DocumentationLayoutGrid.js](https://github.com/confluenza/confluenza/blob/f62a92497d7d3a6f245fda011ede9f8d995ea5d3/workspaces/confluenza/source/documentation-layout/DocumentationLayoutGrid.js#L17).

It turns out that we can achieve the same effect by improving transitioning of the navigation menu, which has been captured in this PR.

The same change has been applied to two files:
- [workspaces/confluenza/source/documentation-layout/DocumentationLayoutSmall.js](https://github.com/confluenza/confluenza/blob/24fe65e057b938f2b795128998f08e698acbd775/workspaces/confluenza/source/documentation-layout/DocumentationLayoutSmall.js)
- [workspaces/component-navigator-react/source/documentation-layout/DocumentationLayoutSmall.js](https://github.com/confluenza/confluenza/blob/24fe65e057b938f2b795128998f08e698acbd775/workspaces/component-navigator-react/source/documentation-layout/DocumentationLayoutSmall.js).

