### PR TITLE
Makes a confluenza custom 404 page working again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ lerna-debug.log
 
 # test coverage
 coverage
+
+.now

--- a/now.json
+++ b/now.json
@@ -1,7 +1,6 @@
 {
   "version": 2,
   "public": true,
-  "name": "confluenza",
   "scope": "confluenza-online",
   "build": {
     "env": {
@@ -31,13 +30,14 @@
     { "src": "/demo-component-navigator/precache-manifest.(.*)", "dest": "/workspaces/demo-component-navigator/precache-manifest.$1"},
     { "src": "/demo-component-navigator/(.*)", "dest": "/workspaces/demo-component-navigator/index.html"},
     {
-      "src": "(?!/workspaces/demo-component-navigator)(.*)",
+      "src": "(.*)",
       "dest": "/workspaces/homepage$1",
       "continue": true
     },
     { "handle": "filesystem" },
     { 
-      "src": "/(?!/workspaces/demo-component-navigator)(.*)",
+      "src": ".*",
+      "status": 404,
       "dest": "/workspaces/homepage/404"
     }
   ]


### PR DESCRIPTION
Routing in Zeit is - well - pain. A big pain. Every few weeks one may expect to something we worked so hard to get...working...breaks. This PR fixes the custom Confluenza 404 page to render when a non existing url is typed. And - on occasion - I've made routing a bit more explicit and minimal.