### PR TITLE
Introduces `ignore` option to allow extending the ignored files and introduces `sortIndex` to improve sorting of navigation items

### DIFF
--- a/workspaces/component-navigator-react/CONFLUENZA.md
+++ b/workspaces/component-navigator-react/CONFLUENZA.md
@@ -3,4 +3,5 @@ path: /packages/confluenza-navigator-react
 title: Confluenza React Navigator
 tag: package
 content: README.md
+sortIndex: 2
 ---

--- a/workspaces/confluenza/CONFLUENZA.md
+++ b/workspaces/confluenza/CONFLUENZA.md
@@ -3,4 +3,5 @@ path: /packages/confluenza
 title: Confluenza NPM package
 tag: package
 content: README.md
+sortIndex: 1
 ---

--- a/workspaces/confluenza/source/navigation/Navigation.js
+++ b/workspaces/confluenza/source/navigation/Navigation.js
@@ -4,6 +4,7 @@ import styled from '@emotion/styled'
 
 import { TopLevelNavigationItem } from './top-level-navigation-item'
 import { NavigationItem } from './NavigationItem'
+import { sort } from './sort'
 
 const List = styled.ul({
   listStyle: 'none',
@@ -82,10 +83,24 @@ export class Navigation extends React.PureComponent {
     return undefined
   }
 
+  sortDocs = docs => {
+    return sort({
+      selector: d => {
+        const n = Number(d.node.frontmatter.sortIndex)
+        return isNaN(n) ? 10 : n
+      },
+      data: docs
+    })
+  }
+
+  filterDocsOnTag = tag => {
+    return this.props.docs.filter(d => d.node.frontmatter.tag === tag)
+  }
+
   createNavigationGroupForTag = ({ title, tag }) => {
     return {
       title,
-      docs: this.props.docs.filter(d => d.node.frontmatter.tag === tag),
+      docs: this.sortDocs(this.filterDocsOnTag(tag)),
       tag
     }
   }

--- a/workspaces/confluenza/source/navigation/sort.js
+++ b/workspaces/confluenza/source/navigation/sort.js
@@ -1,0 +1,32 @@
+const sort = ({
+  selector,
+  data,
+  descending = false
+}) => {
+  data.sort((a, b) => {
+    const propA = selector(a)
+    const propB = selector(b)
+    if (propA === undefined || propB === undefined) {
+      return 0
+    }
+    if (descending) {
+      if (propA > propB) {
+        return -1
+      }
+      if (propA < propB) {
+        return 1
+      }
+    } else {
+      if (propA < propB) {
+        return -1
+      }
+      if (propA > propB) {
+        return 1
+      }
+    }
+    return 0
+  })
+  return data
+}
+
+export { sort }

--- a/workspaces/gatsby-theme-confluenza/CONFLUENZA.md
+++ b/workspaces/gatsby-theme-confluenza/CONFLUENZA.md
@@ -3,4 +3,5 @@ path: /packages/gatsby-theme-confluenza
 title: Confluenza Gatsby Theme
 tag: package
 content: README.md
+sortIndex: 0
 ---

--- a/workspaces/gatsby-theme-confluenza/gatsby-config.js
+++ b/workspaces/gatsby-theme-confluenza/gatsby-config.js
@@ -6,123 +6,126 @@ const workspacesDirNames = ['workspaces', 'packages']
 const rootPath = () => {
   const parentDirName = path.basename(path.resolve(process.cwd(), '..'))
   if (workspacesDirNames.includes(parentDirName)) {
-    return `${process.cwd()}/../../`
+    return path.resolve(`${process.cwd()}/../../`)
   } else {
     return process.cwd()
   }
 }
 
-module.exports = ({ mdx = false }) => ({
-  siteMetadata: {
-    title: 'Confluenza',
-    editBaseUrl: 'https://github.com/confluenza/confluenza/blob/master'
-  },
-  plugins: [
-    {
-      resolve: 'gatsby-source-filesystem',
-      options: {
-        path: `${rootPath()}`,
-        ignore: [
-          '**/.git/**',
-          '**/coverage/**',
-          '**/node_modules/**',
-          '**/.cache/**',
-          '**/public/**',
-          '**/es/**',
-          '**/lib/**',
-          '**/umd/**',
-          '/**/.*'
-        ]
-      }
+module.exports = ({ mdx = false, ignore = [] }) => {
+  return {
+    siteMetadata: {
+      title: 'Confluenza',
+      editBaseUrl: 'https://github.com/confluenza/confluenza/blob/master'
     },
-    {
-      resolve: 'gatsby-plugin-page-creator',
-      options: {
-        path: path.join(__dirname, 'src/pages')
-      }
-    },
-    'gatsby-transformer-yaml',
-    'gatsby-plugin-sharp',
-    {
-      resolve: 'gatsby-transformer-remark',
-      options: {
-        plugins: [
-          'gatsby-remark-autolink-headers',
-          {
-            resolve: 'gatsby-remark-prismjs',
-            options: {
-              // Class prefix for <pre> tags containing syntax highlighting;
-              // defaults to 'language-' (eg <pre class="language-js">).
-              // If your site loads Prism into the browser at runtime,
-              // (eg for use with libraries like react-live),
-              // you may use this to prevent Prism from re-processing syntax.
-              // This is an uncommon use-case though;
-              // If you're unsure, it's best to use the default value.
-              classPrefix: 'language-',
-              // This is used to allow setting a language for inline code
-              // (i.e. single backticks) by creating a separator.
-              // This separator is a string and will do no white-space
-              // stripping.
-              // A suggested value for English speakers is the non-ascii
-              // character '›'.
-              inlineCodeMarker: null
+    plugins: [
+      {
+        resolve: 'gatsby-source-filesystem',
+        options: {
+          path: `${rootPath()}`,
+          ignore: [
+            '**/.git/**',
+            '**/coverage/**',
+            '**/node_modules/**',
+            '**/.cache/**',
+            '**/public/**',
+            '**/es/**',
+            '**/lib/**',
+            '**/umd/**',
+            '/**/.*',
+            ...ignore
+          ]
+        }
+      },
+      {
+        resolve: 'gatsby-plugin-page-creator',
+        options: {
+          path: path.join(__dirname, 'src/pages')
+        }
+      },
+      'gatsby-transformer-yaml',
+      'gatsby-plugin-sharp',
+      {
+        resolve: 'gatsby-transformer-remark',
+        options: {
+          plugins: [
+            'gatsby-remark-autolink-headers',
+            {
+              resolve: 'gatsby-remark-prismjs',
+              options: {
+                // Class prefix for <pre> tags containing syntax highlighting;
+                // defaults to 'language-' (eg <pre class="language-js">).
+                // If your site loads Prism into the browser at runtime,
+                // (eg for use with libraries like react-live),
+                // you may use this to prevent Prism from re-processing syntax.
+                // This is an uncommon use-case though;
+                // If you're unsure, it's best to use the default value.
+                classPrefix: 'language-',
+                // This is used to allow setting a language for inline code
+                // (i.e. single backticks) by creating a separator.
+                // This separator is a string and will do no white-space
+                // stripping.
+                // A suggested value for English speakers is the non-ascii
+                // character '›'.
+                inlineCodeMarker: null
+              }
+            },
+            {
+              resolve: 'gatsby-remark-images',
+              options: {
+                maxWidth: 600
+              }
+            },
+            'gatsby-remark-emoji'
+          ]
+        }
+      },
+      {
+        resolve: 'gatsby-plugin-mdx',
+        options: {
+          remarkPlugins: [emoji],
+          gatsbyRemarkPlugins: [
+            'gatsby-remark-autolink-headers',
+            {
+              resolve: 'gatsby-remark-prismjs',
+              options: {
+                // Class prefix for <pre> tags containing syntax highlighting;
+                // defaults to 'language-' (eg <pre class="language-js">).
+                // If your site loads Prism into the browser at runtime,
+                // (eg for use with libraries like react-live),
+                // you may use this to prevent Prism from re-processing syntax.
+                // This is an uncommon use-case though;
+                // If you're unsure, it's best to use the default value.
+                classPrefix: 'language-',
+                // This is used to allow setting a language for inline code
+                // (i.e. single backticks) by creating a separator.
+                // This separator is a string and will do no white-space
+                // stripping.
+                // A suggested value for English speakers is the non-ascii
+                // character '›'.
+                inlineCodeMarker: null
+              }
+            },
+            {
+              resolve: 'gatsby-remark-images',
+              options: {
+                maxWidth: 600
+              }
             }
-          },
-          {
-            resolve: 'gatsby-remark-images',
-            options: {
-              maxWidth: 600
-            }
-          },
-          'gatsby-remark-emoji'
-        ]
-      }
-    },
-    {
-      resolve: 'gatsby-plugin-mdx',
-      options: {
-        remarkPlugins: [emoji],
-        gatsbyRemarkPlugins: [
-          'gatsby-remark-autolink-headers',
-          {
-            resolve: 'gatsby-remark-prismjs',
-            options: {
-              // Class prefix for <pre> tags containing syntax highlighting;
-              // defaults to 'language-' (eg <pre class="language-js">).
-              // If your site loads Prism into the browser at runtime,
-              // (eg for use with libraries like react-live),
-              // you may use this to prevent Prism from re-processing syntax.
-              // This is an uncommon use-case though;
-              // If you're unsure, it's best to use the default value.
-              classPrefix: 'language-',
-              // This is used to allow setting a language for inline code
-              // (i.e. single backticks) by creating a separator.
-              // This separator is a string and will do no white-space
-              // stripping.
-              // A suggested value for English speakers is the non-ascii
-              // character '›'.
-              inlineCodeMarker: null
-            }
-          },
-          {
-            resolve: 'gatsby-remark-images',
-            options: {
-              maxWidth: 600
-            }
-          }
-        ]
-      }
-    },
-    'gatsby-plugin-react-helmet',
-    {
-      resolve: 'gatsby-plugin-typography',
-      options: {
-        pathToConfigModule: require.resolve('./src/utils/typography')
-      }
-    },
-    'gatsby-plugin-emotion',
-    'gatsby-plugin-catch-links',
-    'gatsby-plugin-layout',
-    'gatsby-plugin-root-import'
-  ]
-})
+          ]
+        }
+      },
+      'gatsby-plugin-react-helmet',
+      {
+        resolve: 'gatsby-plugin-typography',
+        options: {
+          pathToConfigModule: require.resolve('./src/utils/typography')
+        }
+      },
+      'gatsby-plugin-emotion',
+      'gatsby-plugin-catch-links',
+      'gatsby-plugin-layout',
+      'gatsby-plugin-root-import'
+    ]
+  }
+}

--- a/workspaces/gatsby-theme-confluenza/src/layouts/ConfluenzaDocumentationLayout.js
+++ b/workspaces/gatsby-theme-confluenza/src/layouts/ConfluenzaDocumentationLayout.js
@@ -32,6 +32,7 @@ export const MarkdownConnection = graphql`
           title
           path
           tag
+          sortIndex
           content {
             childMarkdownRemark {
               html
@@ -57,6 +58,7 @@ export const MdxDataConnection = graphql`
           title
           path
           tag
+          sortIndex
         }
         headings(depth: h2) {
           value

--- a/workspaces/homepage/gatsby-config.js
+++ b/workspaces/homepage/gatsby-config.js
@@ -7,7 +7,8 @@ module.exports = {
     {
       resolve: '@confluenza/gatsby-theme-confluenza',
       options: {
-        mdx: true
+        mdx: true,
+        ignore: []
       }
     },
     'gatsby-plugin-emotion',

--- a/workspaces/homepage/src/pages/developers/01-MakingConfluenzaYours/01-MakingConfluenzaYours.md
+++ b/workspaces/homepage/src/pages/developers/01-MakingConfluenzaYours/01-MakingConfluenzaYours.md
@@ -3,6 +3,7 @@ path: /developers/making-confluenza-yours
 title: Making Confluenza Yours
 tag: developer
 content: ExternalContent.md
+sortIndex: 0
 ---
 
 ## More

--- a/workspaces/homepage/src/pages/developers/01-MakingConfluenzaYours/ExternalContent.md
+++ b/workspaces/homepage/src/pages/developers/01-MakingConfluenzaYours/ExternalContent.md
@@ -23,6 +23,35 @@ module.exports = {
 }
 ```
 
+`@confluenza/gatsby-theme-confluenza` provides two options: `mdx` and `ignore`. The `mdx` option (default `true`) indicates if you want to support MDX in your documentation site. If you know that the MDX support is not needed, you can set `mdx` to `false` and MDX-related queries will not be run and MDX documents will not be processed:
+
+```javascript
+plugins: [
+  {
+    resolve: '@confluenza/gatsby-theme-confluenza',
+    options: {
+      mdx: false
+    }
+  },
+```
+
+The `ignore` option is handy if you want Confluenza to ignore part of your source tree. It is handy especially when you use confluenza in monorepos with other Markdown-oriented workspaces, which, when exposed to Confluenza, may cause some troubles. For instance, to disable `mdx` and to ignore all files from the `demo-workspace-2` you can use the following configuration:
+
+```javascript
+plugins: [
+  {
+    resolve: '@confluenza/gatsby-theme-confluenza',
+    options: {
+      mdx: false,
+      ignore: [
+        '**/demo-workspace-2/**'
+      ]
+    }
+  },
+```
+
+The format of the `ignore` option is the same as in the [gatsby-source-filesystem](https://www.gatsbyjs.com/plugins/gatsby-source-filesystem/) plugin.
+
 ## frontmatter and confluenza.yml
 
 Every markdown file that is supposed to be rendered by Confluenza needs to have a so called `frontmatter`
@@ -82,6 +111,37 @@ content: ../../../../../CONTRIBUTING.md
 
 Here we see that both documents have the same tag: `developer`. On the other hand, the tag for the document corresponding to Section _Using Confluenza_ is `user`.
 You can use any name you like for a tag. Tags simply inform Confluenza that documents with the given tag should be grouped together under one category in the navigation menu. Following our example, the documents tagged `developer` appear under _Developer Documentation_ category, while the documents tagged `user` under _User Documentation_. How does Confluenza know which category title to use for the given tag? This is what `confluenza.yml` file is for.
+
+## Sorting
+
+In order to sort the navigation entries within each navigation group
+you can add `sortIndex` to the `frontmatter`. `sortIndex` is an integer value which indicates the position of the document in the navigation list. If `sortIndex` is not specified, the default value will be `10`.
+
+For example, the document _Making Confluenza Yours_ has the following `frontmatter`:
+
+```yaml
+---
+path: /developers/making-confluenza-yours
+title: Making Confluenza Yours
+tag: developer
+content: ExternalContent.md
+sortIndex: 0
+---
+```
+
+while _Contributing_ has:
+
+```yaml
+---
+path: /developers/contributing
+title: Contributing
+tag: developer
+content: ../../../../../CONTRIBUTING.md
+sortIndex: 1
+---
+```
+
+Thus, _Making Confluenza Yours_ will be showing in the navigation menu before _Contributing_.
 
 ## confluenza.yml
 

--- a/workspaces/homepage/src/pages/developers/02-Contributing.md
+++ b/workspaces/homepage/src/pages/developers/02-Contributing.md
@@ -3,4 +3,5 @@ path: /developers/contributing
 title: Contributing
 tag: developer
 content: ../../../../../CONTRIBUTING.md
+sortIndex: 1
 ---

--- a/workspaces/homepage/src/pages/users/01-UsingConfluenza.md
+++ b/workspaces/homepage/src/pages/users/01-UsingConfluenza.md
@@ -2,6 +2,7 @@
 path: /users/using-confluenza
 title: Using Confluenza
 tag: user
+sortIndex: 0
 ---
 
 We hope that Confluenza is so simple that you do not really need further

--- a/workspaces/homepage/src/pages/users/02-UsingMDX.mdx
+++ b/workspaces/homepage/src/pages/users/02-UsingMDX.mdx
@@ -2,6 +2,7 @@
 path: /users/mdx
 title: Using MDX in Confluenza
 tag: user
+sortIndex: 1
 ---
 import { WithBorder, ImportingMDXDocuments } from '../../components/mdx'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1867,7 +1867,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@confluenza/component-navigator-react@^1.0.27, @confluenza/component-navigator-react@workspace:workspaces/component-navigator-react":
+"@confluenza/component-navigator-react@^1.0.28, @confluenza/component-navigator-react@workspace:workspaces/component-navigator-react":
   version: 0.0.0-use.local
   resolution: "@confluenza/component-navigator-react@workspace:workspaces/component-navigator-react"
   dependencies:
@@ -1884,7 +1884,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@confluenza/confluenza@^1.0.27, @confluenza/confluenza@workspace:workspaces/confluenza":
+"@confluenza/confluenza@^1.0.28, @confluenza/confluenza@workspace:workspaces/confluenza":
   version: 0.0.0-use.local
   resolution: "@confluenza/confluenza@workspace:workspaces/confluenza"
   dependencies:
@@ -1902,11 +1902,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@confluenza/gatsby-theme-confluenza@^1.0.27, @confluenza/gatsby-theme-confluenza@workspace:workspaces/gatsby-theme-confluenza":
+"@confluenza/gatsby-theme-confluenza@^1.0.28, @confluenza/gatsby-theme-confluenza@workspace:workspaces/gatsby-theme-confluenza":
   version: 0.0.0-use.local
   resolution: "@confluenza/gatsby-theme-confluenza@workspace:workspaces/gatsby-theme-confluenza"
   dependencies:
-    "@confluenza/confluenza": ^1.0.27
+    "@confluenza/confluenza": ^1.0.28
     "@emotion/core": ^11.0.0
     "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0
@@ -10414,7 +10414,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "demo-component-navigator@workspace:workspaces/demo-component-navigator"
   dependencies:
-    "@confluenza/component-navigator-react": ^1.0.27
+    "@confluenza/component-navigator-react": ^1.0.28
     "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0
     "@reach/router": ^1.3.4
@@ -14837,7 +14837,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "homepage@workspace:workspaces/homepage"
   dependencies:
-    "@confluenza/gatsby-theme-confluenza": ^1.0.27
+    "@confluenza/gatsby-theme-confluenza": ^1.0.28
     "@emotion/react": ^11.4.1
     "@emotion/styled": ^11.3.0
     babel-eslint: ^10.1.0


### PR DESCRIPTION
1. Adds support for extending the `ignore` list for the `gatsby-source-filesystem` via `ignore` option in `gatsby-theme-confluenza`.
2. Improves sorting of the navigation menu entries by introducing `sortIndex` in the frontmatter.
3. Updates documentation accordingly.