### PR TITLE
Fixes problem of not showing active menu for root markdown pages

### DIFF
--- a/workspaces/confluenza/source/navigation/Navigation.js
+++ b/workspaces/confluenza/source/navigation/Navigation.js
@@ -117,7 +117,7 @@ export class Navigation extends React.PureComponent {
 
   isActive = docs => {
     if (docs && docs.length > 0) {
-      const filtered = docs.filter(d => withPrefix(d.node.frontmatter.path) === this.props.location.pathname.replace(/\/$/, ''))
+      const filtered = docs.filter(d => withPrefix(d.node.frontmatter.path.replace(/\/$/, '')) === this.props.location.pathname.replace(/\/$/, ''))
       return filtered.length > 0
     }
     return false

--- a/workspaces/confluenza/source/navigation/mid-level-navigation-item/MidLevelNavigationItem.js
+++ b/workspaces/confluenza/source/navigation/mid-level-navigation-item/MidLevelNavigationItem.js
@@ -21,7 +21,7 @@ class MidLevelNavigationItem extends React.Component {
 
   getActiveProps = (currentLocation, href) => {
     const { path: normalizedPathName } = normalizeLocationPath(currentLocation)
-    if (`${normalizedPathName}` === href) {
+    if (`${normalizedPathName}` === href.replace(/\/$/, '')) {
       return 'active'
     }
     return ''


### PR DESCRIPTION
When using frontmatter like this:

```markdown
---
path: /
title: Title
tag: tag
sortIndex: 10
---
```

where `path` is `/`, then navigation menu will not properly update its "active" status (i.e. there will be no marker shown that indicates the selected/opened page.