### PR TITLE
React router 6

### DIFF
--- a/workspaces/component-navigator-react/README.md
+++ b/workspaces/component-navigator-react/README.md
@@ -25,11 +25,12 @@ export { Layout }
 > With [New JSX Transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) introduced in React v17, you no longer need to import React
 > just to use JSX.
 
-You need to provide a `location` object and navigation config in `data`. First, location. We tested `@confluenza/component-navigator-react` with `@reach/router`:
+You need to provide a `location` object and navigation config in `data`. First, location. With React Router v6 you can use `useLocation` hook to get the current location: :
 
 ```jsx
-import { Router, Location } from '@reach/router'
+import { Routes, Route, useLocation } from 'react-router-dom'
 import { Global } from '@emotion/react'
+import { Helmet } from 'react-helmet'
 
 import { Layout } from './Layout'
 
@@ -45,6 +46,7 @@ const Group3Heading1 = () => <div>Group3Heading1</div>
 const Group3Heading2 = () => <div>Group3Heading2</div>
 
 const App = () => {
+  const location = useLocation()
   return (
     <div>
       <Global styles={globalStyles} />
@@ -53,27 +55,23 @@ const App = () => {
         <link href='https://fonts.googleapis.com/css?family=Roboto+Mono:100,100i,300,300i,400,400i,500,500i&display=swap' rel='stylesheet' />
       </Helmet>
 
-      <Location>
-        {({ location }) => (
-          <Layout location={location} data={navigationData}>
-            <Router location={location}>
-              <Group1 path='/' />
-              <Group1Heading1 path='/heading1' />
-              <Group1Heading2 path='/heading2' />
-              <Group2 path='/group-2' />
-              <Group3 path='/group-3' />
-              <Group3Heading1 path='/group-3/heading1' />
-              <Group3Heading2 path='/group-3/heading2' />
-            </Router>
-          </Layout>
-        )}
-      </Location>
+      <Layout location={location} data={navigationData}>
+        <Routes>
+          <Route path='/' element={<Group1 />} />
+          <Route path='/heading1' element={<Group1Heading1 />} />
+          <Route path='/heading2' element={<Group1Heading2 />} />
+          <Route path='/group-2' element={<Group2 />} />
+          <Route path='/group-3' element={<Group3 />} />
+          <Route path='/group-3/heading1' element={<Group3Heading1 />} />
+          <Route path='/group-3/heading2' element={<Group3Heading2 />} />
+        </Routes>
+      </Layout>
     </div>
   )
 }
 ```
 
-As we see, `location` comes directly from the router. We see a number of routes and we also see the corresponding intended paths associated with them.
+In the example above, we see a number of routes and we also see the corresponding intended paths associated with them.
 Now we need to connect these with our navigation component. We use `navigationData` to achieve this:
 
 ```javascript

--- a/workspaces/component-navigator-react/package.json
+++ b/workspaces/component-navigator-react/package.json
@@ -24,9 +24,9 @@
     "react-media": "^1.10.0"
   },
   "peerDependencies": {
-    "@reach/router": "^1.3.4",
     "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react-dom": "^17.0.0",
+    "react-router-dom": "^6.2.1"
   },
   "devDependencies": {
     "@emotion/babel-plugin": "^11.7.2",

--- a/workspaces/component-navigator-react/source/documentation-layout/DocumentationLayout.js
+++ b/workspaces/component-navigator-react/source/documentation-layout/DocumentationLayout.js
@@ -3,37 +3,34 @@ import Media from 'react-media'
 import { DocumentationLayoutSmall } from './DocumentationLayoutSmall'
 import { DocumentationLayoutMedium } from './DocumentationLayoutMedium'
 import { DocumentationLayoutWide } from './DocumentationLayoutWide'
-import { PathPrefixContext } from './PathPrefixContext'
 
-const DocumentationLayout = ({ children, location, data, pathPrefix = '/' }) => {
+const DocumentationLayout = ({ children, location, data }) => {
   return (
-    <PathPrefixContext.Provider value={pathPrefix}>
-      <Media query='(min-width: 1100px)'>
-        {matches =>
-          matches
-            ? (
-              <DocumentationLayoutWide location={location} data={data}>
-                {children}
-              </DocumentationLayoutWide>
-              )
-            : (
-              <Media query='(min-width: 800px)'>
-                {matches =>
-                  matches
-                    ? (
-                      <DocumentationLayoutMedium location={location} data={data}>
-                        {children}
-                      </DocumentationLayoutMedium>
-                      )
-                    : (
-                      <DocumentationLayoutSmall location={location} data={data}>
-                        {children}
-                      </DocumentationLayoutSmall>
-                      )}
-              </Media>
-              )}
-      </Media>
-    </PathPrefixContext.Provider>
+    <Media query='(min-width: 1100px)'>
+      {matches =>
+        matches
+          ? (
+            <DocumentationLayoutWide location={location} data={data}>
+              {children}
+            </DocumentationLayoutWide>
+            )
+          : (
+            <Media query='(min-width: 800px)'>
+              {matches =>
+                matches
+                  ? (
+                    <DocumentationLayoutMedium location={location} data={data}>
+                      {children}
+                    </DocumentationLayoutMedium>
+                    )
+                  : (
+                    <DocumentationLayoutSmall location={location} data={data}>
+                      {children}
+                    </DocumentationLayoutSmall>
+                    )}
+            </Media>
+            )}
+    </Media>
   )
 }
 

--- a/workspaces/component-navigator-react/source/documentation-layout/PathPrefixContext.js
+++ b/workspaces/component-navigator-react/source/documentation-layout/PathPrefixContext.js
@@ -1,9 +1,0 @@
-import React from 'react'
-
-const PathPrefixContext = React.createContext('/')
-
-const withPrefix = (path, pathPrefix) => {
-  return `${pathPrefix}${path}`.replace(/\/$/, '')
-}
-
-export { PathPrefixContext, withPrefix }

--- a/workspaces/component-navigator-react/source/documentation-layout/SiteTitle.js
+++ b/workspaces/component-navigator-react/source/documentation-layout/SiteTitle.js
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 import styled from '@emotion/styled'
-import { Link } from '@reach/router'
+import { Link } from 'react-router-dom'
 import { PathPrefixContext, withPrefix } from './PathPrefixContext'
 
 const Wrapper = styled.div({

--- a/workspaces/component-navigator-react/source/documentation-layout/SiteTitle.js
+++ b/workspaces/component-navigator-react/source/documentation-layout/SiteTitle.js
@@ -1,7 +1,5 @@
-import { useContext } from 'react'
 import styled from '@emotion/styled'
 import { Link } from 'react-router-dom'
-import { PathPrefixContext, withPrefix } from './PathPrefixContext'
 
 const Wrapper = styled.div({
   backgroundColor: 'black',
@@ -26,9 +24,8 @@ const HomeLink = styled(Link)({
 })
 
 const SiteTitle = ({ title }) => {
-  const pathPrefix = useContext(PathPrefixContext)
   return (
-    <HomeLink to={withPrefix('/', pathPrefix)}>
+    <HomeLink to='/'>
       <Wrapper>
         {title}
       </Wrapper>

--- a/workspaces/component-navigator-react/source/documentation-layout/normalizeLocationPath.js
+++ b/workspaces/component-navigator-react/source/documentation-layout/normalizeLocationPath.js
@@ -1,20 +1,5 @@
-import { withPrefix } from './PathPrefixContext'
-
-const includesPathPrefix = (location, pathPrefix) => {
-  const re = new RegExp(`^${withPrefix('/', pathPrefix)}`)
-  return re.test(location)
-}
-
-const removePathPrefix = (location, pathPrefix) => {
-  const re = new RegExp(`^${withPrefix('/', pathPrefix)}`)
-  return location.replace(re, '')
-}
-
-const normalizeLocationPath = (location, pathPrefix) => {
-  let normalizedPath = location.pathname.replace(/\/$/, '')
-  if (includesPathPrefix(normalizedPath, pathPrefix)) {
-    normalizedPath = removePathPrefix(normalizedPath, pathPrefix)
-  }
+const normalizeLocationPath = (location) => {
+  const normalizedPath = location.pathname.replace(/\/$/, '')
   return {
     path: normalizedPath,
     pathWithHash: `${normalizedPath}${location.hash}`

--- a/workspaces/component-navigator-react/source/documentation-layout/useMobileDocumentNavigator.js
+++ b/workspaces/component-navigator-react/source/documentation-layout/useMobileDocumentNavigator.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { navigate } from '@reach/router'
+import { useNavigate } from 'react-router-dom'
 
 import { normalizeLocationPath } from './normalizeLocationPath'
 
@@ -8,6 +8,7 @@ const useMobileDocumentNavigator = ({
   location
 }, deps) => {
   const [prevLocation, setPrevLocation] = useState(undefined)
+  const navigate = useNavigate()
 
   const navigateUnusually = ({ path, pathWithHash }) => {
     setTimeout(() => {

--- a/workspaces/component-navigator-react/source/documentation-layout/useUnusualReloader.js
+++ b/workspaces/component-navigator-react/source/documentation-layout/useUnusualReloader.js
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react'
-import { navigate } from '@reach/router'
+import { useNavigate } from 'react-router-dom'
 import { normalizeLocationPath } from './normalizeLocationPath'
 
 const useUnusualReloader = location => {
   const [ready, setReady] = useState(false)
+  const navigate = useNavigate()
 
   useEffect(() => {
     const { pathWithHash } = normalizeLocationPath(location)

--- a/workspaces/component-navigator-react/source/navigation/Navigation.js
+++ b/workspaces/component-navigator-react/source/navigation/Navigation.js
@@ -3,7 +3,6 @@ import styled from '@emotion/styled'
 
 import { TopLevelNavigationItem } from './top-level-navigation-item'
 import { NavigationItem } from './NavigationItem'
-import { PathPrefixContext, withPrefix } from '../documentation-layout/PathPrefixContext'
 import { sort } from './sort'
 
 const List = styled.ul({
@@ -17,8 +16,6 @@ const List = styled.ul({
 })
 
 export class Navigation extends React.PureComponent {
-  static contextType = PathPrefixContext
-
   navigationGroups
 
   constructor (props) {
@@ -117,12 +114,12 @@ export class Navigation extends React.PureComponent {
     return 0
   }
 
-  isActive = (docs, pathPrefix) => {
+  isActive = docs => {
     if (docs && docs.length > 0) {
       const filtered = docs.filter(d => {
         const headings = d.node.headings || []
-        const subPaths = headings.map(h => withPrefix(h.path, pathPrefix))
-        const normalizedGroupPath = withPrefix(d.node.frontmatter.path, pathPrefix)
+        const subPaths = headings.map(h => h.path)
+        const normalizedGroupPath = d.node.frontmatter.path.replace(/\/$/, '')
         const normalizedLocationPath = this.props.location.pathname.replace(/\/$/, '')
         return normalizedGroupPath === normalizedLocationPath || subPaths.includes(normalizedLocationPath)
       })
@@ -203,7 +200,7 @@ export class Navigation extends React.PureComponent {
       tag={group.tag}
       title={group.title}
       onChange={(delta, el, triggerElement) => this.topLevelNavigationItemChanged(delta, el, triggerElement)}
-      active={this.isActive(group.docs, this.context)}
+      active={this.isActive(group.docs)}
       delta={this.aggregateDeltas(this.state[`${group.tag}Deltas`])}
     >
       <div>

--- a/workspaces/component-navigator-react/source/navigation/NavigationHeading.js
+++ b/workspaces/component-navigator-react/source/navigation/NavigationHeading.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import styled from '@emotion/styled'
-import { useMatch, useLocation } from 'react-router-dom'
+import { useMatch } from 'react-router-dom'
 
 import { NavigationLink } from './NavigationLink'
 
@@ -12,53 +12,19 @@ const Li = styled.li({
 
 const NavigationHeading = ({ path, value, index }) => {
   const [cln, setCln] = useState('')
-  const ref = useRef('')
-  const location = useLocation()
-  console.log('location=', location)
-  // const href = useHref()
-
-  console.log('path[]=', path)
+  const linkRef = useRef('')
 
   const match = useMatch(path)
 
-  console.log('match=', match)
-
-  // const getActiveProps = (currentLocation, href) => {
-  //   this.location = currentLocation.pathname.replace(/\/$/, '')
-  //   this.hash = currentLocation.hash
-  //   this.href = href
-  //   if (this.linkClassName) {
-  //     if (`${this.location}${this.hash}` === this.href) {
-  //       return { className: `${this.linkClassName} active` }
-  //     } else {
-  //       return { className: this.linkClassName }
-  //     }
-  //   }
-  //   return null
-  // }
-
   useEffect(() => {
-    setCln(ref.current.className.replace(/\w*active\w*/, ''))
+    setCln(linkRef.current.className.replace(/\w*active\w*/, ''))
   }, [])
-
-  // const recordLinkNode = node => {
-  //   const linkClassName = node && node.className
-  //   console.log('linkClassName=', linkClassName)
-  //   // setCln(linkClassName)
-  //   // const currentLocation = location.pathname.replace(/\/$/, '')
-  //   // const hash = location.hash
-  //   // if (`${currentLocation}${hash}` === href) {
-  //   //   setCln(`${linkClassName} active`)
-  //   // } else {
-  //   //   setCln(linkClassName)
-  //   // }
-  // }
 
   return (
     <Li key={index}>
       <NavigationLink
         to={path}
-        ref={ref}
+        ref={linkRef}
         className={match ? `${cln} active` : cln}
       >
         {value}

--- a/workspaces/component-navigator-react/source/navigation/NavigationHeading.js
+++ b/workspaces/component-navigator-react/source/navigation/NavigationHeading.js
@@ -1,5 +1,7 @@
-import React from 'react'
+import React, { useContext, useEffect, useRef, useState } from 'react'
 import styled from '@emotion/styled'
+// import { useMatch, useLocation, useHref } from 'react-router-dom'
+import { useMatch, useLocation } from 'react-router-dom'
 
 import { NavigationLink } from './NavigationLink'
 import { PathPrefixContext, withPrefix } from '../documentation-layout/PathPrefixContext'
@@ -10,53 +12,63 @@ const Li = styled.li({
   }
 })
 
-class NavigationHeading extends React.Component {
-  static contextType = PathPrefixContext
+const NavigationHeading = ({ path, value, index }) => {
+  const pathPrefix = useContext(PathPrefixContext)
+  const [cln, setCln] = useState('')
+  console.log(pathPrefix)
+  const ref = useRef('')
+  const location = useLocation()
+  console.log('location=', location)
+  // const href = useHref()
 
-  state = {
-    cln: ''
-  }
+  console.log('path[]=', path)
 
-  getActiveProps = (currentLocation, href) => {
-    this.location = currentLocation.pathname.replace(/\/$/, '')
-    this.hash = currentLocation.hash
-    this.href = href
-    if (this.linkClassName) {
-      if (`${this.location}${this.hash}` === this.href) {
-        return { className: `${this.linkClassName} active` }
-      } else {
-        return { className: this.linkClassName }
-      }
-    }
-    return null
-  }
+  const match = useMatch(path)
 
-  recordLinkNode = node => {
-    this.linkClassName = node && node.className
-    if (`${this.location}${this.hash}` === this.href) {
-      this.setState({ cln: `${this.linkClassName} active` })
-    } else {
-      this.setState({ cln: this.linkClassName })
-    }
-  }
+  console.log('match=', match)
 
-  render () {
-    const { path, value, index } = this.props
-    const pathPrefix = this.context
+  // const getActiveProps = (currentLocation, href) => {
+  //   this.location = currentLocation.pathname.replace(/\/$/, '')
+  //   this.hash = currentLocation.hash
+  //   this.href = href
+  //   if (this.linkClassName) {
+  //     if (`${this.location}${this.hash}` === this.href) {
+  //       return { className: `${this.linkClassName} active` }
+  //     } else {
+  //       return { className: this.linkClassName }
+  //     }
+  //   }
+  //   return null
+  // }
 
-    return (
-      <Li key={index}>
-        <NavigationLink
-          to={withPrefix(path, pathPrefix)}
-          ref={this.recordLinkNode}
-          className={this.state.cln}
-          getProps={({ location, href }) => this.getActiveProps(location, href)}
-        >
-          {value}
-        </NavigationLink>
-      </Li>
-    )
-  }
+  useEffect(() => {
+    setCln(ref.current.className.replace(/\w*active\w*/, ''))
+  }, [])
+
+  // const recordLinkNode = node => {
+  //   const linkClassName = node && node.className
+  //   console.log('linkClassName=', linkClassName)
+  //   // setCln(linkClassName)
+  //   // const currentLocation = location.pathname.replace(/\/$/, '')
+  //   // const hash = location.hash
+  //   // if (`${currentLocation}${hash}` === href) {
+  //   //   setCln(`${linkClassName} active`)
+  //   // } else {
+  //   //   setCln(linkClassName)
+  //   // }
+  // }
+
+  return (
+    <Li key={index}>
+      <NavigationLink
+        to={withPrefix(path, pathPrefix)}
+        ref={ref}
+        className={match ? `${cln} active` : cln}
+      >
+        {value}
+      </NavigationLink>
+    </Li>
+  )
 }
 
 export { NavigationHeading }

--- a/workspaces/component-navigator-react/source/navigation/NavigationHeading.js
+++ b/workspaces/component-navigator-react/source/navigation/NavigationHeading.js
@@ -1,10 +1,8 @@
-import React, { useContext, useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import styled from '@emotion/styled'
-// import { useMatch, useLocation, useHref } from 'react-router-dom'
 import { useMatch, useLocation } from 'react-router-dom'
 
 import { NavigationLink } from './NavigationLink'
-import { PathPrefixContext, withPrefix } from '../documentation-layout/PathPrefixContext'
 
 const Li = styled.li({
   '&:last-child': {
@@ -13,9 +11,7 @@ const Li = styled.li({
 })
 
 const NavigationHeading = ({ path, value, index }) => {
-  const pathPrefix = useContext(PathPrefixContext)
   const [cln, setCln] = useState('')
-  console.log(pathPrefix)
   const ref = useRef('')
   const location = useLocation()
   console.log('location=', location)
@@ -61,7 +57,7 @@ const NavigationHeading = ({ path, value, index }) => {
   return (
     <Li key={index}>
       <NavigationLink
-        to={withPrefix(path, pathPrefix)}
+        to={path}
         ref={ref}
         className={match ? `${cln} active` : cln}
       >

--- a/workspaces/component-navigator-react/source/navigation/NavigationItem.js
+++ b/workspaces/component-navigator-react/source/navigation/NavigationItem.js
@@ -24,7 +24,7 @@ class NavigationItem extends React.Component {
 
     return (
       <li key={path}>
-        <MidLevelNavigationItem location={location} path={path} title={title} onChange={onChange}>
+        <MidLevelNavigationItem location={location} path={path} title={title} headings={headings} onChange={onChange}>
           {headings && headings.length > 0 &&
             <List>
               {headings.map((heading, index) => this.renderNavigationHeading(heading, index, path))}

--- a/workspaces/component-navigator-react/source/navigation/NavigationLink.js
+++ b/workspaces/component-navigator-react/source/navigation/NavigationLink.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Link } from '@reach/router'
+import { Link } from 'react-router-dom'
 
 const NavigationLink = React.forwardRef((props, ref) => (
   <Link

--- a/workspaces/component-navigator-react/source/navigation/mid-level-navigation-item/MidLevelNavigationItem.js
+++ b/workspaces/component-navigator-react/source/navigation/mid-level-navigation-item/MidLevelNavigationItem.js
@@ -19,10 +19,19 @@ class MidLevelNavigationItem extends React.Component {
     this.triggerRef = React.createRef()
   }
 
-  getActiveProps = (currentLocation, href) => {
-    const normalizedHref = href.replace(/\/$/, '')
+  getActiveProps = (currentLocation, path, headings) => {
+    const normalizedPath = path.replace(/\/$/, '')
     const { path: normalizedPathName } = normalizeLocationPath(currentLocation)
-    if (`${normalizedPathName}` === normalizedHref) {
+    // this part (inside the 'if') is responsible for making midlevel item bold
+    // when one of the children is rendered
+    if (headings) {
+      const headingsPaths = headings.map(h => h.path)
+      if (`${normalizedPathName}` === normalizedPath || headingsPaths.includes(normalizedPathName)) {
+        return 'active'
+      }
+      return ''
+    }
+    if (`${normalizedPathName}` === normalizedPath) {
       return 'active'
     }
     return ''
@@ -33,7 +42,7 @@ class MidLevelNavigationItem extends React.Component {
   }
 
   render () {
-    const { title, path, location } = this.props
+    const { title, path, location, headings } = this.props
 
     return (
       <Collapsable
@@ -42,7 +51,7 @@ class MidLevelNavigationItem extends React.Component {
             <NavigationLink
               ref={this.triggerRef}
               to={path}
-              className={this.getActiveProps(location, path)}
+              className={this.getActiveProps(location, path, headings)}
             >
               {title}
             </NavigationLink>

--- a/workspaces/component-navigator-react/source/navigation/mid-level-navigation-item/MidLevelNavigationItem.js
+++ b/workspaces/component-navigator-react/source/navigation/mid-level-navigation-item/MidLevelNavigationItem.js
@@ -4,7 +4,6 @@ import styled from '@emotion/styled'
 import { Collapsable } from '../Collapsable'
 import { NavigationLink } from '../NavigationLink'
 import { normalizeLocationPath } from '../../documentation-layout/normalizeLocationPath'
-import { PathPrefixContext, withPrefix } from '../../documentation-layout/PathPrefixContext'
 
 const Wrapper = styled.div({
   position: 'relative',
@@ -14,17 +13,15 @@ const Wrapper = styled.div({
 })
 
 class MidLevelNavigationItem extends React.Component {
-  static contextType = PathPrefixContext
-
   constructor (props) {
     super(props)
 
     this.triggerRef = React.createRef()
   }
 
-  getActiveProps = (currentLocation, href, pathPrefix) => {
+  getActiveProps = (currentLocation, href) => {
     const normalizedHref = href.replace(/\/$/, '')
-    const { path: normalizedPathName } = normalizeLocationPath(currentLocation, pathPrefix)
+    const { path: normalizedPathName } = normalizeLocationPath(currentLocation)
     if (`${normalizedPathName}` === normalizedHref) {
       return 'active'
     }
@@ -37,7 +34,6 @@ class MidLevelNavigationItem extends React.Component {
 
   render () {
     const { title, path, location } = this.props
-    const pathPrefix = this.context
 
     return (
       <Collapsable
@@ -45,8 +41,8 @@ class MidLevelNavigationItem extends React.Component {
           <Wrapper onClick={() => unfold()}>
             <NavigationLink
               ref={this.triggerRef}
-              to={withPrefix(path, pathPrefix)}
-              className={this.getActiveProps(location, path, pathPrefix)}
+              to={path}
+              className={this.getActiveProps(location, path)}
             >
               {title}
             </NavigationLink>

--- a/workspaces/demo-component-navigator/README.md
+++ b/workspaces/demo-component-navigator/README.md
@@ -1,3 +1,5 @@
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app). 
 
 It is a working demo of using [component-navigation-react] with `create-react-app` based React application.
+
+As an example we deploy the demo-component-navigator app to GitHub pages. Notice, however, that GitHub pages are not really SPA-friendly when in comes to the client side routing. If you want to more more, and learn how this can be fixed for GitHub pages, please consult [Notes on client-side routing](https://create-react-app.dev/docs/deployment/#notes-on-client-side-routing) in the [Create React App documentation](https://create-react-app.dev). We did not bother for this simple demo.

--- a/workspaces/demo-component-navigator/package.json
+++ b/workspaces/demo-component-navigator/package.json
@@ -10,10 +10,10 @@
     "@confluenza/component-navigator-react": "^1.0.36",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
-    "@reach/router": "^1.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",
+    "react-router-dom": "^6.2.1",
     "react-scripts": "5.0.0"
   },
   "scripts": {

--- a/workspaces/demo-component-navigator/src/App.js
+++ b/workspaces/demo-component-navigator/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Router, Location } from '@reach/router'
+import { Routes, Route, useLocation } from 'react-router-dom'
 import { Global } from '@emotion/react'
 import { Helmet } from 'react-helmet'
 
@@ -7,7 +7,6 @@ import { Layout } from './Layout'
 
 import { globalStyles } from './globalStyles'
 import { navigationData } from './navigationData'
-import { withPrefix } from './withPrefix'
 
 const Group1 = () => <div>Group1</div>
 const Group1Heading1 = () => <div>Group1Heading1</div>
@@ -18,6 +17,7 @@ const Group3Heading1 = () => <div>Group3Heading1</div>
 const Group3Heading2 = () => <div>Group3Heading2</div>
 
 const App = () => {
+  const location = useLocation()
   return (
     <div>
       <Global styles={globalStyles} />
@@ -26,21 +26,17 @@ const App = () => {
         <link href='https://fonts.googleapis.com/css?family=Roboto+Mono:100,100i,300,300i,400,400i,500,500i&display=swap' rel='stylesheet' />
       </Helmet>
 
-      <Location>
-        {({ location }) => (
-          <Layout location={location} data={navigationData}>
-            <Router basepath={withPrefix()}>
-              <Group1 path='/' />
-              <Group1Heading1 path='/heading1' />
-              <Group1Heading2 path='/heading2' />
-              <Group2 path='/group-2' />
-              <Group3 path='/group-3' />
-              <Group3Heading1 path='/group-3/heading1' />
-              <Group3Heading2 path='/group-3/heading2' />
-            </Router>
-          </Layout>
-        )}
-      </Location>
+      <Layout location={location} data={navigationData}>
+        <Routes>
+          <Route path='/' element={<Group1 />} />
+          <Route path='/heading1' element={<Group1Heading1 />} />
+          <Route path='/heading2' element={<Group1Heading2 />} />
+          <Route path='/group-2' element={<Group2 />} />
+          <Route path='/group-3' element={<Group3 />} />
+          <Route path='/group-3/heading1' element={<Group3Heading1 />} />
+          <Route path='/group-3/heading2' element={<Group3Heading2 />} />
+        </Routes>
+      </Layout>
     </div>
   )
 }

--- a/workspaces/demo-component-navigator/src/Layout.js
+++ b/workspaces/demo-component-navigator/src/Layout.js
@@ -1,11 +1,10 @@
 import React from 'react'
 
 import { DocumentationLayout } from '@confluenza/component-navigator-react'
-import { withPrefix } from './withPrefix'
 
 const Layout = ({ children, location, data }) => {
   return (
-    <DocumentationLayout location={location} data={data} pathPrefix=''>
+    <DocumentationLayout location={location} data={data}>
       {children}
     </DocumentationLayout>
   )

--- a/workspaces/demo-component-navigator/src/Layout.js
+++ b/workspaces/demo-component-navigator/src/Layout.js
@@ -5,7 +5,7 @@ import { withPrefix } from './withPrefix'
 
 const Layout = ({ children, location, data }) => {
   return (
-    <DocumentationLayout location={location} data={data} pathPrefix={withPrefix()}>
+    <DocumentationLayout location={location} data={data} pathPrefix=''>
       {children}
     </DocumentationLayout>
   )

--- a/workspaces/demo-component-navigator/src/index.js
+++ b/workspaces/demo-component-navigator/src/index.js
@@ -7,7 +7,7 @@ import * as serviceWorker from './serviceWorker'
 
 ReactDOM.render(
   <BrowserRouter basename={withPrefix()}>
-    <App />,
+    <App />
   </BrowserRouter>,
   document.getElementById('root')
 )

--- a/workspaces/demo-component-navigator/src/index.js
+++ b/workspaces/demo-component-navigator/src/index.js
@@ -1,9 +1,16 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import { BrowserRouter } from 'react-router-dom'
+import { withPrefix } from './withPrefix'
 import App from './App'
 import * as serviceWorker from './serviceWorker'
 
-ReactDOM.render(<App />, document.getElementById('root'))
+ReactDOM.render(
+  <BrowserRouter basename={withPrefix()}>
+    <App />,
+  </BrowserRouter>,
+  document.getElementById('root')
+)
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/workspaces/homepage/src/pages/developers/01-MakingConfluenzaYours/ExternalContent.md
+++ b/workspaces/homepage/src/pages/developers/01-MakingConfluenzaYours/ExternalContent.md
@@ -257,7 +257,7 @@ but also helps sites that do not render the frontmatter correctly (like npmjs).
 
 ## Learn more
 
-Confluenza was initially intended to render static markdown documents in your Gatsby site. But now, you can also use a Confluenza-like navigation in any of your other React-based projects (created with `create-react-app` tool). Please consult the documentation of [@confluenza/component-navigator-react](https://confluenza.online/packages/confluenza-navigator-react) and take a look at a <a href="https://demo-component-navigator.confluenza.online" target="_blank" rel="noopener noreferrer">demo</a>.
+Confluenza was initially intended to render static markdown documents in your Gatsby site. But now, you can also use a Confluenza-like navigation in any of your other React-based projects (e.g. created with `create-react-app` tool). Please consult the documentation of [@confluenza/component-navigator-react](https://confluenza.online/packages/confluenza-navigator-react) and take a look at the <a href="https://confluenza.online/demo-component-navigator" target="_blank" rel="noopener noreferrer">demo</a>.
 
 <style scoped>
 .scrollable {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2944,6 +2944,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.7.6":
+  version: 7.17.2
+  resolution: "@babel/runtime@npm:7.17.2"
+  dependencies:
+    regenerator-runtime: ^0.13.4
+  checksum: a48702d271ecc59c09c397856407afa29ff980ab537b3da58eeee1aeaa0f545402d340a1680c9af58aec94dfdcbccfb6abb211991b74686a86d03d3f6956cacd
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.9.2":
   version: 7.16.3
   resolution: "@babel/runtime@npm:7.16.3"
@@ -3076,9 +3085,9 @@ __metadata:
     "@testing-library/react": ^12.1.2
     react-media: ^1.10.0
   peerDependencies:
-    "@reach/router": ^1.3.4
     react: ^17.0.0
     react-dom: ^17.0.0
+    react-router-dom: ^6.2.1
   languageName: unknown
   linkType: soft
 
@@ -5855,21 +5864,6 @@ __metadata:
     webpack-plugin-serve:
       optional: true
   checksum: 66deb75fe06c0d93f9f6f87c57349013cdc82d4cc536b3aff919fd417df1c6603d14a96448d4088f1a680ec22a75f994b30c374a0042c524dfecd96a942ff674
-  languageName: node
-  linkType: hard
-
-"@reach/router@npm:^1.3.4":
-  version: 1.3.4
-  resolution: "@reach/router@npm:1.3.4"
-  dependencies:
-    create-react-context: 0.3.0
-    invariant: ^2.2.3
-    prop-types: ^15.6.1
-    react-lifecycles-compat: ^3.0.4
-  peerDependencies:
-    react: 15.x || 16.x || 16.4.0-alpha.0911da3
-    react-dom: 15.x || 16.x || 16.4.0-alpha.0911da3
-  checksum: f64372497e0464a9fdfd79283fec3f4fd01ee093f1599d8a8035e0a41fbce22113bfa46dcea63aa8b7b4e0796e916f134aa8e3fccd3974be397e7c19468de3c4
   languageName: node
   linkType: hard
 
@@ -10213,19 +10207,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-react-context@npm:0.3.0":
-  version: 0.3.0
-  resolution: "create-react-context@npm:0.3.0"
-  dependencies:
-    gud: ^1.0.0
-    warning: ^4.0.3
-  peerDependencies:
-    prop-types: ^15.0.0
-    react: ^0.14.0 || ^15.0.0 || ^16.0.0
-  checksum: e59b7a65671e59f5b11e06f67faadf0733ab6c33247d5631331aeb05450d180b8ae44d73817b9c02f1527654ba490ea3d3dd7320f8d6debb36776f10b0ae6a47
-  languageName: node
-  linkType: hard
-
 "create-require@npm:^1.1.0":
   version: 1.1.1
   resolution: "create-require@npm:1.1.1"
@@ -11045,10 +11026,10 @@ __metadata:
     "@confluenza/component-navigator-react": ^1.0.36
     "@emotion/react": ^11.7.1
     "@emotion/styled": ^11.6.0
-    "@reach/router": ^1.3.4
     react: ^17.0.2
     react-dom: ^17.0.2
     react-helmet: ^6.1.0
+    react-router-dom: ^6.2.1
     react-scripts: 5.0.0
     serve: ^13.0.2
   languageName: unknown
@@ -14656,13 +14637,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gud@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "gud@npm:1.0.0"
-  checksum: 3e2eb37cf794364077c18f036d6aa259c821c7fd188f2b7935cb00d589d82a41e0ebb1be809e1a93679417f62f1ad0513e745c3cf5329596e489aef8c5e5feae
-  languageName: node
-  linkType: hard
-
 "gzip-size@npm:5.1.1":
   version: 5.1.1
   resolution: "gzip-size@npm:5.1.1"
@@ -15008,6 +14982,15 @@ __metadata:
   version: 10.7.3
   resolution: "highlight.js@npm:10.7.3"
   checksum: defeafcd546b535d710d8efb8e650af9e3b369ef53e28c3dc7893eacfe263200bba4c5fcf43524ae66d5c0c296b1af0870523ceae3e3104d24b7abf6374a4fea
+  languageName: node
+  linkType: hard
+
+"history@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "history@npm:5.2.0"
+  dependencies:
+    "@babel/runtime": ^7.7.6
+  checksum: 2c6a05aa86793e0a0857013457f34474c17f81a012c6bdb00bf30862389ac6a8c2df113d82176f67af2fd534ea9dc4e1218470c5526355b6fc1aefcc971f2eb2
   languageName: node
   linkType: hard
 
@@ -22987,6 +22970,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-router-dom@npm:^6.2.1":
+  version: 6.2.1
+  resolution: "react-router-dom@npm:6.2.1"
+  dependencies:
+    history: ^5.2.0
+    react-router: 6.2.1
+  peerDependencies:
+    react: ">=16.8"
+    react-dom: ">=16.8"
+  checksum: fa0edc69fddf0cb1313bcb3dbd5eb2b2ff24a75ee03ba928995e16a6a251585750f91d966612e868eb68a5aebc4a5240be40fd96c4acf1d8d48d33f54ad3f4e2
+  languageName: node
+  linkType: hard
+
+"react-router@npm:6.2.1":
+  version: 6.2.1
+  resolution: "react-router@npm:6.2.1"
+  dependencies:
+    history: ^5.2.0
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 081a89237ab4f32195d1f2173bc4b3d95637cd6942a4d1a9e90d4ac8c80faa95528255ca2ec44c1e88c1b369e712c4ca74cba5ae3acef6fc30a51a62805b95a4
+  languageName: node
+  linkType: hard
+
 "react-scripts@npm:5.0.0":
   version: 5.0.0
   resolution: "react-scripts@npm:5.0.0"
@@ -27394,15 +27401,6 @@ resolve@^2.0.0-next.3:
   dependencies:
     makeerror: 1.0.12
   checksum: ad7a257ea1e662e57ef2e018f97b3c02a7240ad5093c392186ce0bcf1f1a60bbadd520d073b9beb921ed99f64f065efb63dfc8eec689a80e569f93c1c5d5e16c
-  languageName: node
-  linkType: hard
-
-"warning@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "warning@npm:4.0.3"
-  dependencies:
-    loose-envify: ^1.0.0
-  checksum: 4f2cb6a9575e4faf71ddad9ad1ae7a00d0a75d24521c193fa464f30e6b04027bd97aa5d9546b0e13d3a150ab402eda216d59c1d0f2d6ca60124d96cd40dfa35c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We are beginning the process of redesigning confluenza to accommodate for the new features. We started with the `component-navigator-react` package in which we updated the client-side routing from `@reach/router` to the `react-router` v6. This allowed us to simplify the navigation, especially when the side is to be deployed with a path prefix (as it is in our demo).
