### PR TITLE
fix: removes body attribute from mdx graphql query in markdown template

### DIFF
--- a/workspaces/gatsby-theme-confluenza/src/templates/markdownTemplate.js
+++ b/workspaces/gatsby-theme-confluenza/src/templates/markdownTemplate.js
@@ -81,7 +81,6 @@ export const pageQuery = graphql`
       }
     }
     mdx: mdx(frontmatter: { path: { eq: $templatePath } }) {
-      body
       frontmatter {
         title
       }


### PR DESCRIPTION
In `markdownTemplate.js` we removed the `body` attribute as shown in the following snippet:

```js
export const pageQuery = graphql`
  query ($templatePath: String!) {
    site: site {
      siteMetadata {
        title
        editBaseUrl
      }
    }
    config: allConfluenzaYaml(filter: { tag: { ne: null } }) {
      nodes {
        tag
        title
      }
    }
    doc: markdownRemark(frontmatter: { path: { eq: $templatePath } }) {
      html
      fileAbsolutePath
      frontmatter {
        title
        content {
          childMarkdownRemark {
            html
            fileAbsolutePath
          }
        }
      }
    }
    mdx: mdx(frontmatter: { path: { eq: $templatePath } }) {
      body                                           <<== removed
      frontmatter {
        title
      }
      internal {
        contentFilePath
      }
    }
  }
`
```

As indicated in [Updating page templates](https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/#updating-page-templates) in [gatsby-plugin-mdx](https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/) querying for the `body` on the MDX node is no longer needed and for this reason we remove it. We observed that leaving this attribute when not used triggers errors when using the theme with other Gatsby sites.